### PR TITLE
Fix package import in the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In order to do some classic assertions (using mocha), you can use the default
 asserter:
 
 ```javascript
-import { queryAssert } from "../src"
+import { queryAssert } from "graph-spec"
 import mySchema from "./schema"
 
 it("should say hello world", () =>
@@ -56,7 +56,7 @@ Note that you can pass in the options any of the following GraphQL-js options:
 For ease of use, you can create your own asserter, able to carry preset options:
 
 ```javascript
-import { createQueryAsserter } from "../src"
+import { createQueryAsserter } from "graph-spec"
 import mySchema from "./schema"
 
 const queryAssert = createQueryAsserter(mySchema, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-spec",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "GraphQL assertion and testing made easy",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Instead of hitting a local src, we show how to use it via npm.