### PR TITLE
We move the graphql dependency on peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "mocha": "^2.4.5"
   },
   "dependencies": {
-    "deep-eql": "^0.1.3",
+    "deep-eql": "^0.1.3"
+  },
+  "peerDependencies": {
     "graphql": "^0.6.1"
   }
 }


### PR DESCRIPTION
This way we avoid multiple graphql versions.
